### PR TITLE
Fix pixel clock speeds

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-go-ultra.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-go-ultra.dts
@@ -829,9 +829,9 @@
                                  <0>,
                                  <&clkc CLKID_VCLK2_DIV1>,
                                  <&clkc CLKID_GP0_PLL>;
-        assigned-clock-rates =   <330000000>,
+        assigned-clock-rates =   <344976000>,
                                  <0>,
-                                 <330000000>,
+                                 <344976000>,
                                  <0>,
                                  <0>;
 


### PR DESCRIPTION
Looks like the pixel clock speeds are not correct. We have since fixed this in our JELOS build and should get closer to 60hz. 